### PR TITLE
Generate Pseudo files utility

### DIFF
--- a/l10n-dev/package-lock.json
+++ b/l10n-dev/package-lock.json
@@ -1,16 +1,17 @@
 {
 	"name": "@vscode/l10n-dev",
-	"version": "0.0.11",
+	"version": "0.0.12",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@vscode/l10n-dev",
-			"version": "0.0.11",
+			"version": "0.0.12",
 			"license": "MIT",
 			"dependencies": {
 				"deepmerge-json": "^1.5.0",
 				"glob": "^8.0.3",
+				"pseudo-localization": "^2.4.0",
 				"typescript": "^4.7.4",
 				"xml2js": "^0.4.23",
 				"yargs": "^17.5.1"
@@ -1864,7 +1865,6 @@
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
 			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-			"dev": true,
 			"bin": {
 				"flat": "cli.js"
 			}
@@ -1925,6 +1925,14 @@
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-stdin": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+			"integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/glob": {
@@ -2872,6 +2880,20 @@
 			"resolved": "https://registry.npmjs.org/protochain/-/protochain-1.0.5.tgz",
 			"integrity": "sha512-4hDwFSX50C4NE6f/6zg8EPr/WLPTkFPUtG0ulWZu6bwzV2hmb50fpdQLr0HiKBAUehapaFpItzWoCLjraLJhUA==",
 			"dev": true
+		},
+		"node_modules/pseudo-localization": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/pseudo-localization/-/pseudo-localization-2.4.0.tgz",
+			"integrity": "sha512-ISYMOKY8+f+PmiXMFw2y6KLY74LBrv/8ml/VjjoVEV2k+MS+OJZz7ydciK5ntJwxPrKQPTU1+oXq9Mx2b0zEzg==",
+			"dependencies": {
+				"flat": "^5.0.2",
+				"get-stdin": "^7.0.0",
+				"typescript": "^4.7.4",
+				"yargs": "^17.2.1"
+			},
+			"bin": {
+				"pseudo-localization": "bin/pseudo-localize"
+			}
 		},
 		"node_modules/punycode": {
 			"version": "2.1.1",
@@ -4988,8 +5010,7 @@
 		"flat": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-			"dev": true
+			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
 		},
 		"flat-cache": {
 			"version": "3.0.4",
@@ -5035,6 +5056,11 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+		},
+		"get-stdin": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+			"integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ=="
 		},
 		"glob": {
 			"version": "8.0.3",
@@ -5747,6 +5773,17 @@
 			"resolved": "https://registry.npmjs.org/protochain/-/protochain-1.0.5.tgz",
 			"integrity": "sha512-4hDwFSX50C4NE6f/6zg8EPr/WLPTkFPUtG0ulWZu6bwzV2hmb50fpdQLr0HiKBAUehapaFpItzWoCLjraLJhUA==",
 			"dev": true
+		},
+		"pseudo-localization": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/pseudo-localization/-/pseudo-localization-2.4.0.tgz",
+			"integrity": "sha512-ISYMOKY8+f+PmiXMFw2y6KLY74LBrv/8ml/VjjoVEV2k+MS+OJZz7ydciK5ntJwxPrKQPTU1+oXq9Mx2b0zEzg==",
+			"requires": {
+				"flat": "^5.0.2",
+				"get-stdin": "^7.0.0",
+				"typescript": "^4.7.4",
+				"yargs": "^17.2.1"
+			}
 		},
 		"punycode": {
 			"version": "2.1.1",

--- a/l10n-dev/package.json
+++ b/l10n-dev/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vscode/l10n-dev",
-	"version": "0.0.11",
+	"version": "0.0.12",
 	"description": "Development time npm module to generate strings bundles from TypeScript files",
 	"author": "Microsoft Corporation",
 	"license": "MIT",
@@ -39,6 +39,7 @@
 	"dependencies": {
 		"deepmerge-json": "^1.5.0",
 		"glob": "^8.0.3",
+		"pseudo-localization": "^2.4.0",
 		"typescript": "^4.7.4",
 		"xml2js": "^0.4.23",
 		"yargs": "^17.5.1"

--- a/l10n-dev/src/cli.ts
+++ b/l10n-dev/src/cli.ts
@@ -204,17 +204,13 @@ async function l10nImportXlf(paths: string[], outDir: string): Promise<void> {
 	console.log(`Wrote ${count} localized L10N JSON files to: ${outDir}`);
 }
 
-function toPosixPath(pathToConvert: string): string {
-	return pathToConvert.split(path.win32.sep).join(path.posix.sep);
-}
-
 function l10nGeneratePseudo(paths: string[], language: string): void {
 	console.log('Searching for L10N JSON files...');
-	const matches = paths.map(p => glob.sync(p)).flat();
+	const matches = paths.map(p => glob.sync(toPosixPath(p))).flat();
 	matches.forEach(curr => {
 		const results = curr.endsWith('.l10n.json') || curr.endsWith('package.nls.json')
 			? [curr]
-			: glob.sync(path.join(curr, `{,!(node_modules)/**}`, '{*.l10n.json,package.nls.json}'));
+			: glob.sync(path.posix.join(curr, `{,!(node_modules)/**}`, '{*.l10n.json,package.nls.json}'));
 		for (const result of results) {
 			if (result.endsWith('.l10n.json')) {
 				const name = path.basename(curr).split('.l10n.json')[0] ?? '';
@@ -233,4 +229,8 @@ function l10nGeneratePseudo(paths: string[], language: string): void {
 		return;
 	}
 	console.log(`Wrote ${matches.length} L10N JSON files.`);
+}
+
+function toPosixPath(pathToConvert: string): string {
+	return pathToConvert.split(path.win32.sep).join(path.posix.sep);
 }

--- a/l10n-dev/src/main.ts
+++ b/l10n-dev/src/main.ts
@@ -67,7 +67,14 @@ export async function getL10nFilesFromXlf(xlfContents: string): Promise<l10nJson
 	return details;
 }
 
-export function getL10nPseudoLocalized(contents: l10nJsonFormat): l10nJsonFormat {
+/**
+ * Get pseudo localized l10n data for a given l10n bundle
+ * @param contents package.nls.json or bundle.l10n.json contents parsed
+ * @returns l10nJsonFormat
+ */
+export function getL10nPseudoLocalized(dataToLocalize: l10nJsonFormat): l10nJsonFormat {
+	// deep clone
+	const contents = JSON.parse(JSON.stringify(dataToLocalize));
 	for(const key of Object.keys(contents)) {
 		const value = contents[key];
 		const message = typeof value === 'string' ? value : value!.message;

--- a/l10n-dev/src/test/main.test.ts
+++ b/l10n-dev/src/test/main.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { getL10nFilesFromXlf, getL10nJson, getL10nXlf } from "../main";
+import { getL10nFilesFromXlf, getL10nJson, getL10nPseudoLocalized, getL10nXlf } from "../main";
 
 describe('main', () => {
 	context('getL10nJson', () => {
@@ -88,6 +88,22 @@ vscode.l10n.t("Hello World");
 			details = await getL10nFilesFromXlf(generateTextXLF('pt-BR'))
 			assert.strictEqual(details.length, 2);
 			assert.strictEqual(details[0]!.language, 'pt-br');
+		});
+	});
+
+	context('getL10nPseudoLocalized', () => {
+		it('works', () => {
+			const l10nContents = {
+				// base case
+				Hello: 'Hello',
+				// icon syntax should not be localized
+				'$(alert) Hello': '$(alert) Hello',
+				// command syntax should not be localized
+				'[hello](command:hello)': '[hello](command:hello)',
+			};
+
+			const result = getL10nPseudoLocalized(l10nContents);
+			assert.strictEqual(JSON.stringify(result), '{"Hello":"Ħḗḗŀŀǿǿ","$(alert) Hello":"$(alert) Ħḗḗŀŀǿǿ","[hello](command:hello)":"[ħḗḗŀŀǿǿ](command:hello)"}');
 		});
 	});
 });

--- a/l10n-dev/src/test/main.test.ts
+++ b/l10n-dev/src/test/main.test.ts
@@ -100,10 +100,15 @@ vscode.l10n.t("Hello World");
 				'$(alert) Hello': '$(alert) Hello',
 				// command syntax should not be localized
 				'[hello](command:hello)': '[hello](command:hello)',
+				// supports long syntax
+				'Hello/Hello': {
+					message: 'Hello',
+					comment: ['Hello']
+				}
 			};
 
 			const result = getL10nPseudoLocalized(l10nContents);
-			assert.strictEqual(JSON.stringify(result), '{"Hello":"Ħḗḗŀŀǿǿ","$(alert) Hello":"$(alert) Ħḗḗŀŀǿǿ","[hello](command:hello)":"[ħḗḗŀŀǿǿ](command:hello)"}');
+			assert.strictEqual(JSON.stringify(result), '{"Hello":"Ħḗḗŀŀǿǿ","$(alert) Hello":"$(alert) Ħḗḗŀŀǿǿ","[hello](command:hello)":"[ħḗḗŀŀǿǿ](command:hello)","Hello/Hello":"Ħḗḗŀŀǿǿ"}');
 		});
 	});
 });


### PR DESCRIPTION
adds a command that can generate a pseudo language bundle. Skips over `command:` and `$(icon)` syntaxes. 