### PR TITLE
Use hash for id

### DIFF
--- a/l10n-dev/package-lock.json
+++ b/l10n-dev/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@vscode/l10n-dev",
-	"version": "0.0.12",
+	"version": "0.0.13",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@vscode/l10n-dev",
-			"version": "0.0.12",
+			"version": "0.0.13",
 			"license": "MIT",
 			"dependencies": {
 				"deepmerge-json": "^1.5.0",

--- a/l10n-dev/package.json
+++ b/l10n-dev/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vscode/l10n-dev",
-	"version": "0.0.12",
+	"version": "0.0.13",
 	"description": "Development time npm module to generate strings bundles from TypeScript files",
 	"author": "Microsoft Corporation",
 	"license": "MIT",

--- a/l10n-dev/src/test/main.test.ts
+++ b/l10n-dev/src/test/main.test.ts
@@ -38,7 +38,7 @@ vscode.l10n.t("Hello World");
 				'Hello Universe': 'Hello Universe',
 			});
 			const xlf = getL10nXlf(map);
-			assert.strictEqual(xlf, '<?xml version="1.0" encoding="utf-8"?>\r\n<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">\r\n  <file original="a" source-language="en" datatype="plaintext"><body>\r\n    <trans-unit id="Hello World">\r\n      <source xml:lang="en">Hello World</source>\r\n    </trans-unit>\r\n  </body></file>\r\n  <file original="b" source-language="en" datatype="plaintext"><body>\r\n    <trans-unit id="Hello Universe">\r\n      <source xml:lang="en">Hello Universe</source>\r\n    </trans-unit>\r\n  </body></file>\r\n</xliff>');
+			assert.strictEqual(xlf, '<?xml version="1.0" encoding="utf-8"?>\r\n<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">\r\n  <file original="a" source-language="en" datatype="plaintext"><body>\r\n    <trans-unit id="a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e">\r\n      <source xml:lang="en">Hello World</source>\r\n    </trans-unit>\r\n  </body></file>\r\n  <file original="b" source-language="en" datatype="plaintext"><body>\r\n    <trans-unit id="d73d0e9e4c117844d0621a950e8b65c635d023e12a5e6f80b89d077a6b14a71b">\r\n      <source xml:lang="en">Hello Universe</source>\r\n    </trans-unit>\r\n  </body></file>\r\n</xliff>');
 		});
 	});
 
@@ -49,7 +49,7 @@ vscode.l10n.t("Hello World");
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file original="package" source-language="en" datatype="plaintext" target-language="${language}">
     <body>
-      <trans-unit id="description">
+      <trans-unit id="185f8db32271fe25f561a6fc938b2e264306ec304eda518007d1764826381969">
         <source xml:lang="en">Hello</source>
         <target state="new">World</target>
       </trans-unit>
@@ -72,10 +72,10 @@ vscode.l10n.t("Hello World");
 			assert.strictEqual(details.length, 2);
 			assert.strictEqual(details[0]!.name, 'package');
 			assert.strictEqual(details[0]!.language, 'de');
-			assert.strictEqual(details[0]!.messages['description'], 'World');
+			assert.strictEqual(details[0]!.messages['Hello'], 'World');
 			assert.strictEqual(details[1]!.name, 'bundle');
 			assert.strictEqual(details[1]!.language, 'de');
-			assert.strictEqual(details[1]!.messages['description'], 'World');
+			assert.strictEqual(details[1]!.messages['Hello'], 'World');
 		});
 
 		it('properly changes some of the languages based on VS Code language packs', async () => {

--- a/l10n-dev/src/xlf/test/xlf.test.ts
+++ b/l10n-dev/src/xlf/test/xlf.test.ts
@@ -11,7 +11,7 @@ describe('XLF', () => {
         const xlf = new XLF();
         xlf.addFile('bundle', { Hello: 'Hello' });
         const result = xlf.toString();
-        assert.strictEqual(result, '<?xml version="1.0" encoding="utf-8"?>\r\n<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">\r\n  <file original="bundle" source-language="en" datatype="plaintext"><body>\r\n    <trans-unit id="Hello">\r\n      <source xml:lang="en">Hello</source>\r\n    </trans-unit>\r\n  </body></file>\r\n</xliff>');
+        assert.strictEqual(result, '<?xml version="1.0" encoding="utf-8"?>\r\n<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">\r\n  <file original="bundle" source-language="en" datatype="plaintext"><body>\r\n    <trans-unit id="185f8db32271fe25f561a6fc938b2e264306ec304eda518007d1764826381969">\r\n      <source xml:lang="en">Hello</source>\r\n    </trans-unit>\r\n  </body></file>\r\n</xliff>');
     });
 
 
@@ -19,19 +19,19 @@ describe('XLF', () => {
         const xlf = new XLF();
         // Use to of each to ensure we don't accidentally just grab the first one
         xlf.addFile('bundle', {
-            '""': 'quotes',
-            "''": 'apostrophes',
-            '<<': 'less than',
-            '>>': 'greater than',
-            '&&': 'ampersands'
+            '""': '""',
+            "''": "''",
+            '<<': '<<',
+            '>>': '>>',
+            '&&': '&&'
         });
         const result = xlf.toString();
         const header = '<?xml version="1.0" encoding="utf-8"?>\r\n<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">\r\n  <file original="bundle" source-language="en" datatype="plaintext"><body>';
-        const quotes = '\r\n    <trans-unit id="&quot;&quot;">\r\n      <source xml:lang="en">quotes</source>\r\n    </trans-unit>';
-        const apostrophes = '\r\n    <trans-unit id="&apos;&apos;">\r\n      <source xml:lang="en">apostrophes</source>\r\n    </trans-unit>';
-        const lessThan = '\r\n    <trans-unit id="&lt;&lt;">\r\n      <source xml:lang="en">less than</source>\r\n    </trans-unit>';
-        const greaterThan = '\r\n    <trans-unit id="&gt;&gt;">\r\n      <source xml:lang="en">greater than</source>\r\n    </trans-unit>';
-        const amp = '\r\n    <trans-unit id="&amp;&amp;">\r\n      <source xml:lang="en">ampersands</source>\r\n    </trans-unit>';
+        const quotes = '\r\n    <trans-unit id="12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126">\r\n      <source xml:lang="en">&quot;&quot;</source>\r\n    </trans-unit>';
+        const apostrophes = '\r\n    <trans-unit id="6f49cdbd80e1b95d5e6427e1501fc217790daee87055fa5b4e71064288bddede">\r\n      <source xml:lang="en">&apos;&apos;</source>\r\n    </trans-unit>';
+        const lessThan = '\r\n    <trans-unit id="4be261c018f23deac37f17f24abb5f42c4f32044fa3116d7b618446fb03ca09e">\r\n      <source xml:lang="en">&lt;&lt;</source>\r\n    </trans-unit>';
+        const greaterThan = '\r\n    <trans-unit id="0f02c6bad08d9ff1858d26cf1af766e336d71e34c2e74e8c7d417b3550cbfc44">\r\n      <source xml:lang="en">&gt;&gt;</source>\r\n    </trans-unit>';
+        const amp = '\r\n    <trans-unit id="73e7b6f86214bc78ee505fb5f7d4fb97cfa99924a67ca3105113c9a3d52f8fef">\r\n      <source xml:lang="en">&amp;&amp;</source>\r\n    </trans-unit>';
         const footer = '\r\n  </body></file>\r\n</xliff>';
         assert.strictEqual(result, header + quotes + apostrophes + lessThan + greaterThan + amp + footer);
     });
@@ -42,23 +42,23 @@ describe('XLF', () => {
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
 <file original="package" source-language="en" datatype="plaintext" target-language="de">
 <body>
-    <trans-unit id="&quot;&quot;">
+    <trans-unit id="12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126">
         <source xml:lang="en">&quot;&quot;</source>
         <target state="translated">&quot;&quot;</target>
     </trans-unit>
-    <trans-unit id="&apos;&apos;">
+    <trans-unit id="6f49cdbd80e1b95d5e6427e1501fc217790daee87055fa5b4e71064288bddede">
         <source xml:lang="en">&apos;&apos;</source>
         <target state="translated">&apos;&apos;</target>
     </trans-unit>
-    <trans-unit id="&lt;&lt;">
+    <trans-unit id="4be261c018f23deac37f17f24abb5f42c4f32044fa3116d7b618446fb03ca09e">
         <source xml:lang="en">&lt;&lt;</source>
         <target state="translated">&lt;&lt;</target>
     </trans-unit>
-    <trans-unit id="&gt;&gt;">
+    <trans-unit id="0f02c6bad08d9ff1858d26cf1af766e336d71e34c2e74e8c7d417b3550cbfc44">
         <source xml:lang="en">&gt;&gt;</source>
         <target state="translated">&gt;&gt;</target>
     </trans-unit>
-    <trans-unit id="&amp;&amp;">
+    <trans-unit id="73e7b6f86214bc78ee505fb5f7d4fb97cfa99924a67ca3105113c9a3d52f8fef">
         <source xml:lang="en">&amp;&amp;</source>
         <target state="translated">&amp;&amp;</target>
     </trans-unit>


### PR DESCRIPTION
We do this to avoid the 512 limit that the localization team has.

Luckily the id is useless to us as we can re-compute it from the source