### PR TITLE
Support object args to align with API

### DIFF
--- a/l10n-dev/src/main.ts
+++ b/l10n-dev/src/main.ts
@@ -81,7 +81,7 @@ export function getL10nPseudoLocalized(dataToLocalize: l10nJsonFormat): l10nJson
 		let index = 0;
 		let localized = '';
 		// escape command and icon syntax
-		for (const match of message.matchAll(/(?:\(command:\S+)|(?:\$\([A-Za-z-~]+\))/g)) {
+		for (const match of message.matchAll(/(?:\(command:\S+)|(?:\$\([A-Za-z-~]+\))|(?:\{\S+\})/g)) {
 			const section = localize(message.substring(index, match.index));
 			localized += section + match[0]!;
 			index = match.index! + match[0]!.length;

--- a/l10n-dev/src/test/main.test.ts
+++ b/l10n-dev/src/test/main.test.ts
@@ -100,6 +100,8 @@ vscode.l10n.t("Hello World");
 				'$(alert) Hello': '$(alert) Hello',
 				// command syntax should not be localized
 				'[hello](command:hello)': '[hello](command:hello)',
+				// arguments syntax (just the 'this', not the whole { } string) should not be localized
+				'{Hello {this}}': '{Hello {this}}',
 				// supports long syntax
 				'Hello/Hello': {
 					message: 'Hello',
@@ -108,7 +110,7 @@ vscode.l10n.t("Hello World");
 			};
 
 			const result = getL10nPseudoLocalized(l10nContents);
-			assert.strictEqual(JSON.stringify(result), '{"Hello":"Ħḗḗŀŀǿǿ","$(alert) Hello":"$(alert) Ħḗḗŀŀǿǿ","[hello](command:hello)":"[ħḗḗŀŀǿǿ](command:hello)","Hello/Hello":"Ħḗḗŀŀǿǿ"}');
+			assert.strictEqual(JSON.stringify(result), '{"Hello":"Ħḗḗŀŀǿǿ","$(alert) Hello":"$(alert) Ħḗḗŀŀǿǿ","[hello](command:hello)":"[ħḗḗŀŀǿǿ](command:hello)","{Hello {this}}":"{Ħḗḗŀŀǿǿ {this}}","Hello/Hello":"Ħḗḗŀŀǿǿ"}');
 		});
 	});
 });

--- a/l10n/package-lock.json
+++ b/l10n/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@vscode/l10n",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@vscode/l10n",
-			"version": "0.0.3",
+			"version": "0.0.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/mocha": "^9.1.1",

--- a/l10n/package.json
+++ b/l10n/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vscode/l10n",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"description": "A helper library to assist in localizing subprocesses spun up by VS Code extensions",
 	"author": "Microsoft Corporation",
 	"license": "MIT",

--- a/l10n/src/main.ts
+++ b/l10n/src/main.ts
@@ -36,40 +36,79 @@ export function config(config: { uri: string | URL; } | { contents: string | l10
     }
 }
 
-const _formatRegexp = /{(\d+)}/g;
+const _format2Regexp = /{([^}]+)}/g;
 
 /**
- * Helper to produce a string with a variable number of arguments. Insert variable segments
- * into the string using the {n} notation where N is the index of the argument following the string.
- * @param value string to which formatting is applied
- * @param args replacements for {n}-entries
+ * Helper to create a string from a template and a string record.
+ * Similar to `format` but with objects instead of positional arguments.
  * 
- * Copied from https://github.com/microsoft/vscode/blob/4f26134e3bdf7830921f6a9d75a653bfecb72b45/src/vs/base/common/strings.ts#L18-L36
+ * Copied from https://github.com/microsoft/vscode/blob/5dfca53892a1061b1c103542afe49d51f1041778/src/vs/base/common/strings.ts#L44
  */
-function format(value: string, ...args: any[]): string {
-	if (args.length === 0) {
-		return value;
-	}
-	return value.replace(_formatRegexp, function (match, group) {
-		const idx = parseInt(group, 10);
-		return isNaN(idx) || idx < 0 || idx >= args.length ?
-			match :
-			args[idx];
-	});
+export function format(template: string, values: Record<string, unknown>): string {
+	return template.replace(_format2Regexp, (match, group) => (values[group] ?? match) as string);
 }
 
-export function t(str: string, ...args: any[]): string;
-export function t(options: { message: string; args?: any[]; comment?: string[] }): string;
-export function t(...args: [str: string, ...args: string[]] | [options: { message: string; args?: any[]; comment?: string[] }]): string {
+/**
+ * Marks a string for localization. If a localized bundle is available for the language specified by
+ * {@link env.language} and the bundle has a localized value for this message, then that localized
+ * value will be returned (with injected {@link args} values for any templated values).
+ * @param message The message to localize. Supports index templating where strings like {0} and {1} are
+ * replaced by the item at that index in the {@link args} array.
+ * @param args The arguments to be used in the localized string. The index of the argument is used to
+ * match the template placeholder in the localized string.
+ * @returns localized string with injected arguments.
+ * @example l10n.localize('hello', 'Hello {0}!', 'World');
+ */
+export function t(message: string, ...args: Array<string | number>): string;
+/**
+ * Marks a string for localization. If a localized bundle is available for the language specified by
+ * {@link env.language} and the bundle has a localized value for this message, then that localized
+ * value will be returned (with injected {@link args} values for any templated values).
+ * @param message The message to localize. Supports named templating where strings like {foo} and {bar} are
+ * replaced by the value in the Record for that key (foo, bar, etc).
+ * @param args The arguments to be used in the localized string. The name of the key in the record is used to
+ * match the template placeholder in the localized string.
+ * @returns localized string with injected arguments.
+ * @example l10n.t('Hello {name}', { name: 'Erich' });
+ */
+export function t(message: string, args: Record<string, any>): string;
+
+/**
+ * Marks a string for localization. If a localized bundle is available for the language specified by
+ * {@link env.language} and the bundle has a localized value for this message, then that localized
+ * value will be returned (with injected args values for any templated values).
+ * @param options The options to use when localizing the message.
+ * @returns localized string with injected arguments.
+ */
+export function t(options: {
+    /**
+     * The message to localize. If {@link args} is an array, this message supports index templating where strings like
+     * {0} and {1} are replaced by the item at that index in the {@link args} array. If args is a Record<string, any>,
+     * this supports named templating where strings like {foo} and {bar} are replaced by the value in
+     * the Record for that key (foo, bar, etc).
+     */
+    message: string;
+    /**
+     * The arguments to be used in the localized string. As an array, the index of the argument is used to
+     * match the template placeholder in the localized string. As a Record, the key is used to match the template
+     * placeholder in the localized string.
+     */
+    args?: Array<string | number> | Record<string, any>;
+    /**
+     * A comment to help translators understand the context of the message.
+     */
+    comment: string[];
+}): string;
+export function t(...args: [str: string, ...args: Array<string | number>] | [message: string, args: Record<string, any>] | [options: { message: string; args?: Array<string | number> | Record<string, any>; comment?: string[] }]): string {
     const firstArg = args[0];
     let key: string;
     let message: string;
-    let formatArgs: any[] | undefined;
+    let formatArgs: Array<string | number> | Record<string, any> | undefined;
     if (typeof firstArg === 'string') {
         key = firstArg;
         message = firstArg;
         args.splice(0, 1);
-        formatArgs = args;
+        formatArgs = !args || typeof args[0] !== 'object' ? args : args[0];
     } else {
         message = firstArg.message;
         key = message;
@@ -77,23 +116,23 @@ export function t(...args: [str: string, ...args: string[]] | [options: { messag
             // in the format: message/commentcommentcomment
             key += `/${firstArg.comment.join()}`;
         }
-        formatArgs = firstArg.args as any[] ?? [];
+        formatArgs = firstArg.args as any[] ?? {};
     }
     if (!bundle) {
-        return format(message, ...formatArgs);
+        return format(message, formatArgs as Record<string, unknown>);
     }
 
     const messageFromBundle = bundle[key];
     if (!messageFromBundle) {
-        return format(message, ...formatArgs);
+        return format(message, formatArgs as Record<string, unknown>);
     }
 
     if (typeof messageFromBundle === 'string') {
-        return format(messageFromBundle, ...formatArgs);
+        return format(messageFromBundle, formatArgs as Record<string, unknown>);
     }
     
     if (messageFromBundle.comment) {
-        return format(messageFromBundle.message, ...formatArgs);
+        return format(messageFromBundle.message, formatArgs as Record<string, unknown>);
     }
-    return format(message, ...formatArgs);
+    return format(message, formatArgs as Record<string, unknown>);
 }

--- a/l10n/src/test/main.test.ts
+++ b/l10n/src/test/main.test.ts
@@ -60,7 +60,7 @@ describe('@vscode/l10n', () => {
         }
     });
 
-    it('supports args', () => {
+    it('supports index args', () => {
         l10n.config({
             contents: {
                 message: 'translated {0} message {1}'
@@ -68,6 +68,16 @@ describe('@vscode/l10n', () => {
         });
 
         assert.strictEqual(l10n.t("message", "foo", "bar"), "translated foo message bar");
+    });
+
+    it('supports record args', () => {
+        l10n.config({
+            contents: {
+                message: 'translated {this} message {that}'
+            }
+        });
+
+        assert.strictEqual(l10n.t("message", { this: "foo", that: "bar" }), "translated foo message bar");
     });
 
     it('supports comments', () => {
@@ -91,7 +101,7 @@ describe('@vscode/l10n', () => {
         }), result);
     });
 
-    it('supports args and comments', () => {
+    it('supports index args and comments', () => {
         const message = 'message {0}';
         const comment = 'This is a comment';
         const result = 'translated message foo';
@@ -110,6 +120,28 @@ describe('@vscode/l10n', () => {
             message,
             comment: [comment],
             args: ['foo']
+        }), result);
+    });
+
+    it('supports object args and comments', () => {
+        const message = 'message {this}';
+        const comment = 'This is a comment';
+        const result = 'translated message foo';
+
+        const key = `${message}/${comment}`;
+
+        l10n.config({
+            contents: {
+                [key]: { message: 'translated message {this}', comment: [comment] }
+            }
+        });
+
+        // Normally we would be more static in the declaration of the object 
+        // in order to extract them properly but for tests we don't need to do that.
+        assert.strictEqual(l10n.t({
+            message,
+            comment: [comment],
+            args: { this: 'foo' }
         }), result);
     });
 });


### PR DESCRIPTION
* l10n-dev pseudo should not localize `{this}`
* l10n should use the same format function as Core