### PR TITLE
Support JS files

### DIFF
--- a/l10n-dev/package-lock.json
+++ b/l10n-dev/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@vscode/l10n-dev",
-	"version": "0.0.17",
+	"version": "0.0.18",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@vscode/l10n-dev",
-			"version": "0.0.17",
+			"version": "0.0.18",
 			"license": "MIT",
 			"dependencies": {
 				"deepmerge-json": "^1.5.0",

--- a/l10n-dev/package.json
+++ b/l10n-dev/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vscode/l10n-dev",
-	"version": "0.0.17",
+	"version": "0.0.18",
 	"description": "Development time npm module to generate strings bundles from TypeScript files",
 	"author": "Microsoft Corporation",
 	"license": "MIT",

--- a/l10n-dev/src/ast/analyzer.ts
+++ b/l10n-dev/src/ast/analyzer.ts
@@ -19,6 +19,7 @@ export class ScriptAnalyzer {
         const filename = `file${extension}`;
         const options: ts.CompilerOptions = {};
         options.noResolve = true;
+        options.allowJs = true;
         const serviceHost = new SingleFileServiceHost(options, filename, contents);
         const service = ts.createLanguageService(serviceHost);
         const sourceFile = service.getProgram()!.getSourceFile(filename)!;

--- a/l10n-dev/src/ast/test/analyzer.test.ts
+++ b/l10n-dev/src/ast/test/analyzer.test.ts
@@ -16,6 +16,18 @@ describe('ScriptAnalyzer', () => {
         assert.strictEqual(result.bundle[basecaseText], basecaseText);
     });
 
+    it('require basecase js', () => {
+        const analyzer = new ScriptAnalyzer();
+        const result = analyzer.analyze({
+            extension: '.js',
+            contents: `
+                const vscode = require('vscode');
+                vscode.l10n.t('${basecaseText}');`
+        });
+        assert.strictEqual(Object.keys(result.bundle).length, 1);
+        assert.strictEqual(result.bundle[basecaseText], basecaseText);
+    });
+
     it('require basecase object binding', () => {
         const analyzer = new ScriptAnalyzer();
         const result = analyzer.analyze({
@@ -158,6 +170,23 @@ describe('ScriptAnalyzer', () => {
         const analyzer = new ScriptAnalyzer();
         const result = analyzer.analyze({
             extension: '.tsx',
+            contents: `
+                import React from 'react';
+                import * as l10n from '@vscode/l10n';
+                function foo() {
+                    return (
+                        <textarea placeholder={l10n.t('${basecaseText}')} />
+                    );
+                }`
+        });
+        assert.strictEqual(Object.keys(result.bundle).length, 1);
+        assert.strictEqual(result.bundle[basecaseText], basecaseText);
+    });
+
+    it('@vscode/l10n jsx works', () => {
+        const analyzer = new ScriptAnalyzer();
+        const result = analyzer.analyze({
+            extension: '.jsx',
             contents: `
                 import React from 'react';
                 import * as l10n from '@vscode/l10n';

--- a/l10n-dev/src/cli.ts
+++ b/l10n-dev/src/cli.ts
@@ -103,20 +103,22 @@ yargs(hideBin(process.argv))
 .help().argv;
 
 function l10nExportStrings(paths: string[], outDir: string): void {
-	console.log('Searching for TypeScript files...');
+	console.log('Searching for TypeScript/JavaScript files...');
 	const matches = paths.map(p => glob.sync(toPosixPath(p))).flat();
 	const tsFileContents = matches.reduce<IScriptFile[]>((prev, curr) => {
 		const ext = path.extname(curr);
 		switch(ext) {
 			case '.ts':
 			case '.tsx':
+			case '.js':
+			case '.jsx':
 				prev.push({
 					extension: ext,
 					contents: readFileSync(path.resolve(curr), 'utf8')
 				});
 				break;
 		}
-		const results = glob.sync(path.posix.join(curr, `{,!(node_modules)/**}`, '*.{ts,tsx}'));
+		const results = glob.sync(path.posix.join(curr, '{,**}', '*.{ts,tsx,js,jsx}'));
 		for (const result of results) {
 			prev.push({
 				extension: path.extname(result),

--- a/l10n-dev/src/test/main.test.ts
+++ b/l10n-dev/src/test/main.test.ts
@@ -18,12 +18,39 @@ describe('main', () => {
 			assert.strictEqual(JSON.stringify(result), '{"Hello World":"Hello World"}');
 		});
 
+		it('works for js', () => {
+			const result = getL10nJson([{
+				extension: '.js',
+				contents: `
+					const vscode = require("vscode");
+					vscode.l10n.t("Hello World");`
+			}]);
+			assert.strictEqual(JSON.stringify(result), '{"Hello World":"Hello World"}');
+		});
+
 		it('works for tsx', () => {
 			const result = getL10nJson([{
 				extension: '.tsx',
 				contents: `
 					import React from 'react';
 					import * as l10n from '@vscode/l10n';
+					function foo() {
+						return (
+							<span>
+								<textarea placeholder={l10n.t('Hello World')} />
+								<span>{l10n.t('Hello Globe')}</span>
+							</span>
+						);
+					}`
+			}]);
+			assert.strictEqual(JSON.stringify(result), '{"Hello World":"Hello World","Hello Globe":"Hello Globe"}');
+		});
+
+		it('works for jsx', () => {
+			const result = getL10nJson([{
+				extension: '.jsx',
+				contents: `
+					const l10n = require('@vscode/l10n');
 					function foo() {
 						return (
 							<span>


### PR DESCRIPTION
emmet has an emmet helper npm library that runs in the extension host... when building vscode, that helper library is JS so this change will also pick up calls to `vscode.l10n.t` in that library as well.