### PR TITLE
Support running in browsers

### DIFF
--- a/l10n/.esbuild.config.js
+++ b/l10n/.esbuild.config.js
@@ -1,33 +1,54 @@
 const esbuild = require('esbuild');
 const path = require('path');
 const { Extractor, ExtractorConfig } = require('@microsoft/api-extractor');
-const { dependencies, peerDependencies } = require('./package.json')
 
 const watch = process.argv.includes('--watch');
 const type = watch ? 'watch' : 'compile';
 
-console.log(`[${type}] build started`);
-esbuild.buildSync({
+const sharedConfig = {
 	entryPoints: ['src/main.ts'],
 	bundle: true,
-	watch,
+	watch: !watch ? false : {
+		onRebuild(error, result) {
+			console.log(`[${type}] build started`)
+			if (error) {
+				error.errors.forEach((error) => console.error(`> ${error.location.file}:${error.location.line}:${error.location.column}: error: ${error.text}`))
+			} else {
+				console.log(`[${type}] build finished`)
+			}
+		},
+	},
 	sourcemap: watch,
-	external: Object.keys(dependencies ?? {}).concat(Object.keys(peerDependencies ?? {})),
-	platform: 'node',
 	minify: !watch,
-	outfile: 'dist/main.js',
-});
-console.log(`[${type}] build finished`);
-
-if (watch) {
-	return;
 }
 
-console.log(`[${type}] generating types started`);
-const extractorResult = Extractor.invoke(ExtractorConfig.loadFileAndPrepare(path.join(__dirname, './api-extractor.json')));
-
-if (!extractorResult.succeeded) {
-	console.error(`API Extractor completed with ${extractorResult.errorCount} errors and ${extractorResult.warningCount} warnings`);
-	process.exit(1);
-}
-console.log(`[${type}] generating types finished`);
+console.log(`[${type}] build started`);
+Promise.all([
+	esbuild.build({
+		...sharedConfig,
+		platform: 'node',
+		outfile: 'dist/main.js',
+	}),
+	esbuild.build({
+		...sharedConfig,
+		platform: 'browser',
+		outfile: 'dist/browser.js',
+	})
+])
+.then(() => {
+	console.log(`[${type}] build finished`);
+	
+	if (watch) {
+		return;
+	}
+	
+	console.log(`[${type}] generating types started`);
+	const extractorResult = Extractor.invoke(ExtractorConfig.loadFileAndPrepare(path.join(__dirname, './api-extractor.json')));
+	
+	if (!extractorResult.succeeded) {
+		console.error(`API Extractor completed with ${extractorResult.errorCount} errors and ${extractorResult.warningCount} warnings`);
+		process.exit(1);
+	}
+	console.log(`[${type}] generating types finished`);
+})
+.catch(() => process.exit(1));

--- a/l10n/package-lock.json
+++ b/l10n/package-lock.json
@@ -1,18 +1,19 @@
 {
 	"name": "@vscode/l10n",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@vscode/l10n",
-			"version": "0.0.6",
+			"version": "0.0.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@microsoft/api-extractor": "^7.32.1",
 				"@types/mocha": "^9.1.1",
 				"@types/mock-fs": "^4.13.1",
 				"@types/node": "^18.7.8",
+				"@types/node-fetch": "^2.6.2",
 				"@typescript-eslint/eslint-plugin": "^4.28.0",
 				"@typescript-eslint/parser": "^4.28.0",
 				"esbuild": "^0.15.5",
@@ -20,6 +21,7 @@
 				"import-fresh": "^3.3.0",
 				"mocha": "^10.0.0",
 				"mock-fs": "^5.1.4",
+				"node-fetch": "^2.6.7",
 				"rimraf": "^3.0.2",
 				"ts-node": "^10.9.1",
 				"typescript": "^4.7.4"
@@ -437,6 +439,16 @@
 			"integrity": "sha512-/YP55EMK2341JkODUb8DM9O0x1SIz2aBvyF33Uf1c76St3VpsMXEIW0nxuKkq/5cxnbz0RD9cfwNZHEAZQD3ag==",
 			"dev": true
 		},
+		"node_modules/@types/node-fetch": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+			"integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*",
+				"form-data": "^3.0.0"
+			}
+		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "4.33.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
@@ -725,6 +737,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"dev": true
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -858,6 +876,18 @@
 				"node": ">=0.1.90"
 			}
 		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -925,6 +955,15 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
+		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.0"
+			}
 		},
 		"node_modules/diff": {
 			"version": "5.0.0",
@@ -1691,6 +1730,20 @@
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
 		},
+		"node_modules/form-data": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+			"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+			"dev": true,
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/fs-extra": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -2158,6 +2211,27 @@
 				"node": ">=8.6"
 			}
 		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dev": true,
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2312,6 +2386,26 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
+		},
+		"node_modules/node-fetch": {
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"dev": true,
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -2832,6 +2926,12 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"dev": true
+		},
 		"node_modules/ts-node": {
 			"version": "10.9.1",
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
@@ -2991,6 +3091,22 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.10"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"dev": true
+		},
+		"node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"dev": true,
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/which": {
@@ -3518,6 +3634,16 @@
 			"integrity": "sha512-/YP55EMK2341JkODUb8DM9O0x1SIz2aBvyF33Uf1c76St3VpsMXEIW0nxuKkq/5cxnbz0RD9cfwNZHEAZQD3ag==",
 			"dev": true
 		},
+		"@types/node-fetch": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+			"integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"form-data": "^3.0.0"
+			}
+		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "4.33.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
@@ -3696,6 +3822,12 @@
 			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
 			"dev": true
 		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"dev": true
+		},
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3797,6 +3929,15 @@
 			"integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
 			"dev": true
 		},
+		"combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
+		},
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -3846,6 +3987,12 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+			"dev": true
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
 			"dev": true
 		},
 		"diff": {
@@ -4327,6 +4474,17 @@
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
 		},
+		"form-data": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+			"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+			"dev": true,
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			}
+		},
 		"fs-extra": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -4682,6 +4840,21 @@
 				"picomatch": "^2.3.1"
 			}
 		},
+		"mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"dev": true
+		},
+		"mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dev": true,
+			"requires": {
+				"mime-db": "1.52.0"
+			}
+		},
 		"minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4800,6 +4973,15 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
+		},
+		"node-fetch": {
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"dev": true,
+			"requires": {
+				"whatwg-url": "^5.0.0"
+			}
 		},
 		"normalize-path": {
 			"version": "3.0.0",
@@ -5149,6 +5331,12 @@
 				"is-number": "^7.0.0"
 			}
 		},
+		"tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"dev": true
+		},
 		"ts-node": {
 			"version": "10.9.1",
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
@@ -5252,6 +5440,22 @@
 			"resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
 			"integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
 			"dev": true
+		},
+		"webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"dev": true
+		},
+		"whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"dev": true,
+			"requires": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
 		},
 		"which": {
 			"version": "2.0.2",

--- a/l10n/package.json
+++ b/l10n/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vscode/l10n",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"description": "A helper library to assist in localizing subprocesses spun up by VS Code extensions",
 	"author": "Microsoft Corporation",
 	"license": "MIT",
@@ -12,6 +12,9 @@
 		"url": "https://github.com/Microsoft/vscode-l10n/issues"
 	},
 	"main": "dist/main.js",
+	"browser": {
+		"./src/node/reader": "./src/browser/reader"
+	},
 	"types": "dist/main.d.ts",
 	"files": [
 		"dist/*"
@@ -21,6 +24,7 @@
 		"@types/mocha": "^9.1.1",
 		"@types/mock-fs": "^4.13.1",
 		"@types/node": "^18.7.8",
+		"@types/node-fetch": "^2.6.2",
 		"@typescript-eslint/eslint-plugin": "^4.28.0",
 		"@typescript-eslint/parser": "^4.28.0",
 		"esbuild": "^0.15.5",
@@ -28,6 +32,7 @@
 		"import-fresh": "^3.3.0",
 		"mocha": "^10.0.0",
 		"mock-fs": "^5.1.4",
+		"node-fetch": "^2.6.7",
 		"rimraf": "^3.0.2",
 		"ts-node": "^10.9.1",
 		"typescript": "^4.7.4"

--- a/l10n/src/browser/reader.ts
+++ b/l10n/src/browser/reader.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export async function readFileFromUri(uri: URL): Promise<string> {
+    if (uri.protocol === 'http' || uri.protocol === 'https') {
+        const res = await fetch(uri);
+        return await res.text();
+    }
+    throw new Error('Unsupported protocol');
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function readFileFromFsPath(_: string): string {
+    throw new Error('Unsupported in browser');
+}

--- a/l10n/src/node/reader.ts
+++ b/l10n/src/node/reader.ts
@@ -11,7 +11,7 @@ export async function readFileFromUri(uri: URL): Promise<string> {
     if (uri.protocol === 'file:') {
         return await readFile(uri, 'utf8');
     }
-    if (uri.protocol === 'http' || uri.protocol === 'https') {
+    if (uri.protocol === 'http:' || uri.protocol === 'https:') {
         const res = await fetch(uri);
         return await res.text();
     }

--- a/l10n/src/node/reader.ts
+++ b/l10n/src/node/reader.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { readFileSync } from 'fs';
+import { readFile } from 'fs/promises';
+import fetch from 'node-fetch';
+
+export async function readFileFromUri(uri: URL): Promise<string> {
+    if (uri.protocol === 'file:') {
+        return await readFile(uri, 'utf8');
+    }
+    if (uri.protocol === 'http' || uri.protocol === 'https') {
+        const res = await fetch(uri);
+        return await res.text();
+    }
+    throw new Error('Unsupported protocol');
+}
+
+export function readFileFromFsPath(fsPath: string): string {
+    return readFileSync(fsPath, 'utf8');
+}

--- a/l10n/src/test/main.test.ts
+++ b/l10n/src/test/main.test.ts
@@ -31,12 +31,12 @@ describe('@vscode/l10n', () => {
         assert.strictEqual(l10n.t("message"), "translated message");
     });
 
-    it('load from uri', () => {
+    it('load from uri', async () => {
         mock({
             '/mock-bundle.json': `{ "message": "translated message" }`,
             'C:\\mock-bundle.json': `{ "message": "translated message" }`
         });
-        l10n.config({ uri: new URL(platform === 'win32' ? 'file:///c:/mock-bundle.json' : 'file:///mock-bundle.json') });
+        await l10n.config({ uri: new URL(platform === 'win32' ? 'file:///c:/mock-bundle.json' : 'file:///mock-bundle.json') });
 
         try {
             assert.strictEqual(l10n.t("message"), "translated message");
@@ -45,13 +45,28 @@ describe('@vscode/l10n', () => {
         }
     });
 
-    it('load from uri as string', () => {
+    it('load from uri as string', async () => {
+        mock({
+            '/mock-bundle.json': `{ "message": "translated message" }`,
+            'C:\\mock-bundle.json': `{ "message": "translated message" }`
+        });
+        await l10n.config({
+            uri: new URL(platform === 'win32' ? 'file:///c:/mock-bundle.json' : 'file:///mock-bundle.json').toString()
+        });
+        try {
+            assert.strictEqual(l10n.t("message"), "translated message");
+        } finally {
+            mock.restore();
+        }
+    });
+
+    it('load from fsPath', async () => {
         mock({
             '/mock-bundle.json': `{ "message": "translated message" }`,
             'C:\\mock-bundle.json': `{ "message": "translated message" }`
         });
         l10n.config({
-            uri: new URL(platform === 'win32' ? 'file:///c:/mock-bundle.json' : 'file:///mock-bundle.json').toString()
+            fsPath: platform === 'win32' ? 'C:\\mock-bundle.json' : '/mock-bundle.json'
         });
         try {
             assert.strictEqual(l10n.t("message"), "translated message");


### PR DESCRIPTION
So that webworkers can be localized.

Kinda a big PR but in short it's:

* abstracting away any OS operations so that now there's a node & browser separation of file reading logic
* have 3 different `config` overloads (contents - best, fsPath - node only, Uri - async)
* esbuild updates to support main and browser 