### PR TITLE
Properly support browsers

### DIFF
--- a/l10n/.esbuild.config.js
+++ b/l10n/.esbuild.config.js
@@ -31,8 +31,16 @@ Promise.all([
 	}),
 	esbuild.build({
 		...sharedConfig,
+		format: 'iife',
+		globalName: 'l10n',
 		platform: 'browser',
 		outfile: 'dist/browser.js',
+	}),
+	esbuild.build({
+		...sharedConfig,
+		format: 'esm',
+		platform: 'browser',
+		outfile: 'dist/browser.esm.js',
 	})
 ])
 .then(() => {

--- a/l10n/package-lock.json
+++ b/l10n/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@vscode/l10n",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@vscode/l10n",
-			"version": "0.0.9",
+			"version": "0.0.10",
 			"license": "MIT",
 			"devDependencies": {
 				"@microsoft/api-extractor": "^7.32.1",

--- a/l10n/package.json
+++ b/l10n/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vscode/l10n",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"description": "A helper library to assist in localizing subprocesses spun up by VS Code extensions",
 	"author": "Microsoft Corporation",
 	"license": "MIT",
@@ -16,6 +16,7 @@
 		"./dist/main.js": "./dist/browser.js",
 		"./src/node/reader": "./src/browser/reader"
 	},
+	"module": "./dist/browser.esm.js",
 	"types": "dist/main.d.ts",
 	"files": [
 		"dist/*"

--- a/l10n/src/test/smoke.esm.html
+++ b/l10n/src/test/smoke.esm.html
@@ -1,0 +1,25 @@
+<div id="mocha" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mocha/8.0.1/mocha.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/chai/4.2.0/chai.min.js"></script>
+
+<script type="module">
+import * as l10n from '../../dist/browser.esm.js';
+mocha.setup('bdd');
+
+l10n.config({
+    contents: {
+        'Hello': 'Hallo'
+    }
+});
+
+describe('test', () => {
+    it('has value', () => {
+        chai.expect(l10n.t('Hello')).to.eql('Hallo');
+    });
+    it('fallback', () => {
+        chai.expect(l10n.t('hi')).to.eql('hi');
+    });
+});
+
+mocha.run();
+</script>

--- a/l10n/src/test/smoke.iife.html
+++ b/l10n/src/test/smoke.iife.html
@@ -1,0 +1,24 @@
+<div id="mocha" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mocha/8.0.1/mocha.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/chai/4.2.0/chai.min.js"></script>
+<script src="../../dist/browser.js"></script>
+<script>
+mocha.setup('bdd');
+
+l10n.config({
+    contents: {
+        'Hello': 'Hallo'
+    }
+});
+
+describe('test', () => {
+    it('has value', () => {
+        chai.expect(l10n.t('Hello')).to.eql('Hallo');
+    });
+    it('fallback', () => {
+        chai.expect(l10n.t('hi')).to.eql('hi');
+    });
+});
+
+mocha.run();
+</script>


### PR DESCRIPTION
Before, I don't think you could actually use this package because it never had a global name in the `iife` case...

So this gives a global name to the `iife` and also adds an `esm` target for anyone using modules.

I added a couple of html files that act as a manual smoke tests for these two cases too.