### PR TITLE
Parse XLF notes correctly

### DIFF
--- a/l10n-dev/package-lock.json
+++ b/l10n-dev/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@vscode/l10n-dev",
-	"version": "0.0.18",
+	"version": "0.0.19",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@vscode/l10n-dev",
-			"version": "0.0.18",
+			"version": "0.0.19",
 			"license": "MIT",
 			"dependencies": {
 				"deepmerge-json": "^1.5.0",

--- a/l10n-dev/package.json
+++ b/l10n-dev/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vscode/l10n-dev",
-	"version": "0.0.18",
+	"version": "0.0.19",
 	"description": "Development time npm module to generate strings bundles from TypeScript files",
 	"author": "Microsoft Corporation",
 	"license": "MIT",

--- a/l10n-dev/src/xlf/test/xlf.test.ts
+++ b/l10n-dev/src/xlf/test/xlf.test.ts
@@ -94,6 +94,45 @@ describe('XLF', () => {
             assert.strictEqual(result[1]!.messages['id'], 'World');
         });
 
+        it('parses comments correctly by excluding newlines', async () => {
+            const result = await XLF.parse(`
+    <?xml version="1.0" encoding="utf-8"?>
+    <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file original="bundle" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+        <trans-unit id="++CODE++12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126">
+            <source xml:lang="en">Hello</source>
+            <target state="translated">World</target>
+            <note>note1
+note2</note>
+        </trans-unit>
+    </body>
+    </file>
+    <file original="package" source-language="en" datatype="plaintext" target-language="de">
+    <body>
+        <trans-unit id="id">
+            <source xml:lang="en">Hello</source>
+            <target state="translated">World</target>
+            <note>note1
+note2</note>
+        </trans-unit>
+    </body>
+    </file>
+    </xliff>`);
+
+            assert.ok(result);
+            assert.strictEqual(result.length, 2);
+            assert.strictEqual(result[0]!.language, 'de');
+            assert.strictEqual(result[0]!.name, 'bundle');
+            assert.ok(result[0]!.messages['Hello/note1note2']);
+            assert.strictEqual(result[0]!.messages['Hello/note1note2'], 'World');
+
+            assert.strictEqual(result[1]!.language, 'de');
+            assert.strictEqual(result[1]!.name, 'package');
+            assert.ok(result[1]!.messages['id']);
+            assert.strictEqual(result[1]!.messages['id'], 'World');
+        });
+
         it('parses double quotes correctly', async () => {
             const result = await XLF.parse(`
     <?xml version="1.0" encoding="utf-8"?>

--- a/l10n-dev/src/xlf/xlf.ts
+++ b/l10n-dev/src/xlf/xlf.ts
@@ -172,7 +172,7 @@ export class XLF {
 						const note = getValue(unit.note);
 						key = source;
 						if (note) {
-							key += '/' + note.split(/(\r\n|\n)/).join(''); // remove newlines
+							key += '/' + note.replace(/\r?\n/, ''); // remove newlines
 						}
 					}
 


### PR DESCRIPTION
Part of:
https://github.com/microsoft/vscode/issues/165735

This fixes the problem where the translated string wasn't being read from the bundle correctly, because this bad regex was including newlines in the key that was generated when it shouldn't have.