### PR TITLE
Export with spaces

### DIFF
--- a/l10n-dev/src/cli.ts
+++ b/l10n-dev/src/cli.ts
@@ -143,7 +143,7 @@ function l10nExportStrings(paths: string[], outDir: string): void {
 	const resolvedOutFile = path.resolve(path.join(outDir, 'bundle.l10n.json'));
 	console.log(`Writing exported strings to: ${resolvedOutFile}`);
 	mkdirSync(path.resolve(outDir), { recursive: true });
-	writeFileSync(resolvedOutFile, JSON.stringify(jsonResult));
+	writeFileSync(resolvedOutFile, JSON.stringify(jsonResult, undefined, 2));
 }
 
 function l10nGenerateXlf(paths: string[], language: string, outFile: string): void {


### PR DESCRIPTION
Since most users will manually interact with the exported file.

Fixes https://github.com/microsoft/vscode-l10n/issues/54