### PR TITLE
Allow WASM files to be loaded in the CLI

### DIFF
--- a/l10n-dev/.esbuild.config.mjs
+++ b/l10n-dev/.esbuild.config.mjs
@@ -1,7 +1,11 @@
-const esbuild = require('esbuild');
-const path = require('path');
-const { Extractor, ExtractorConfig } = require('@microsoft/api-extractor');
-const { dependencies, peerDependencies } = require('./package.json')
+import esbuild from 'esbuild';
+import path from 'path';
+import copy from 'esbuild-copy-files-plugin';
+import { Extractor, ExtractorConfig } from '@microsoft/api-extractor';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { dependencies, peerDependencies } = require('./package.json');
 
 const watch = process.argv.includes('--watch');
 const type = watch ? 'watch' : 'compile';
@@ -31,6 +35,13 @@ Promise.all([
 		...sharedConfig,
 		entryPoints: ['src/main.ts'],
 		outfile: 'dist/main.js',
+		plugins: [
+			copy({
+				source: ['./src/ast/tree-sitter-tsx.wasm', './src/ast/tree-sitter-typescript.wasm'],
+				target: './dist',
+				copyWithFolder: false
+			})
+		]
 	}),
 	esbuild.build({
 		...sharedConfig,

--- a/l10n-dev/package-lock.json
+++ b/l10n-dev/package-lock.json
@@ -30,6 +30,7 @@
 				"@typescript-eslint/eslint-plugin": "^4.28.0",
 				"@typescript-eslint/parser": "^4.28.0",
 				"esbuild": "^0.15.5",
+				"esbuild-copy-files-plugin": "^1.1.0",
 				"eslint": "^7.29.0",
 				"mocha": "^10.0.0",
 				"mock-fs": "^5.1.4",
@@ -1139,6 +1140,12 @@
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/esbuild-copy-files-plugin": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/esbuild-copy-files-plugin/-/esbuild-copy-files-plugin-1.1.0.tgz",
+			"integrity": "sha512-8aRiwJ0owGuyUXzCJIcbwoTDRWpn/g7cfrGKRBrIUNpR3n8eqh12Yj5PmToHmgTUe23xng5oyIoMgX/gRYbdJw==",
+			"dev": true
 		},
 		"node_modules/esbuild-darwin-64": {
 			"version": "0.15.5",
@@ -4243,6 +4250,12 @@
 			"integrity": "sha512-YyEkaQl08ze3cBzI/4Cm1S+rVh8HMOpCdq8B78JLbNFHhzi4NixVN93xDrHZLztlocEYqi45rHHCgA8kZFidFg==",
 			"dev": true,
 			"optional": true
+		},
+		"esbuild-copy-files-plugin": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/esbuild-copy-files-plugin/-/esbuild-copy-files-plugin-1.1.0.tgz",
+			"integrity": "sha512-8aRiwJ0owGuyUXzCJIcbwoTDRWpn/g7cfrGKRBrIUNpR3n8eqh12Yj5PmToHmgTUe23xng5oyIoMgX/gRYbdJw==",
+			"dev": true
 		},
 		"esbuild-darwin-64": {
 			"version": "0.15.5",

--- a/l10n-dev/package.json
+++ b/l10n-dev/package.json
@@ -14,9 +14,7 @@
 	"main": "dist/main.js",
 	"types": "dist/main.d.ts",
 	"files": [
-		"dist/*",
-		"tree-sitter-tsx.wasm",
-		"tree-sitter-typescript.wasm"
+		"dist/*"
 	],
 	"bin": {
 		"vscode-l10n-dev": "./dist/cli.js"
@@ -32,6 +30,7 @@
 		"@typescript-eslint/eslint-plugin": "^4.28.0",
 		"@typescript-eslint/parser": "^4.28.0",
 		"esbuild": "^0.15.5",
+		"esbuild-copy-files-plugin": "^1.1.0",
 		"eslint": "^7.29.0",
 		"mocha": "^10.0.0",
 		"mock-fs": "^5.1.4",
@@ -49,13 +48,13 @@
 		"yargs": "^17.5.1"
 	},
 	"scripts": {
-		"build-wasm-typescript": "tree-sitter build-wasm ./node_modules/tree-sitter-typescript/typescript",
-		"build-wasm-tsx": "tree-sitter build-wasm ./node_modules/tree-sitter-typescript/tsx",
+		"build-wasm-typescript": "tree-sitter build-wasm ./node_modules/tree-sitter-typescript/typescript && mv ./tree-sitter-typescript.wasm ./src/ast/tree-sitter-typescript.wasm",
+		"build-wasm-tsx": "tree-sitter build-wasm ./node_modules/tree-sitter-typescript/tsx && mv ./tree-sitter-tsx.wasm ./src/ast/tree-sitter-tsx.wasm",
 		"build-wasm": "npm run build-wasm-typescript && npm run build-wasm-tsx",
 		"clean": "rimraf dist && rimraf lib",
-		"compile": "npm run clean && tsc --emitDeclarationOnly --outDir lib && node .esbuild.config.js",
+		"compile": "npm run clean && tsc --emitDeclarationOnly --outDir lib && node .esbuild.config.mjs",
 		"lint": "eslint src --ext ts",
-		"watch": "node .esbuild.config.js --watch",
+		"watch": "node .esbuild.config.mjs --watch",
 		"test": "mocha",
 		"prepublishOnly": "npm run lint && npm run compile && npm run test"
 	}

--- a/l10n-dev/src/ast/analyzer.ts
+++ b/l10n-dev/src/ast/analyzer.ts
@@ -111,7 +111,7 @@ export class ScriptAnalyzer {
 					await Parser.init();
 					ScriptAnalyzer.#tsxParser = new Parser();
 					ScriptAnalyzer.#tsxGrammar = await Parser.Language.load(
-						path.resolve(__dirname, '..', '..', 'tree-sitter-tsx.wasm')
+						path.resolve(__dirname, 'tree-sitter-tsx.wasm')
 					);
 					ScriptAnalyzer.#tsxParser.setLanguage(ScriptAnalyzer.#tsxGrammar);
 				}
@@ -124,7 +124,7 @@ export class ScriptAnalyzer {
 					await Parser.init();
 					ScriptAnalyzer.#tsParser = new Parser();
 					ScriptAnalyzer.#tsGrammar = await Parser.Language.load(
-						path.resolve(__dirname, '..', '..', 'tree-sitter-typescript.wasm')
+						path.resolve(__dirname, 'tree-sitter-typescript.wasm')
 					);
 					ScriptAnalyzer.#tsParser.setLanguage(ScriptAnalyzer.#tsGrammar);
 				}
@@ -136,7 +136,6 @@ export class ScriptAnalyzer {
 				throw new Error(`File format '${extension}' not supported.`);
 		}
 
-		parser.setLanguage(grammar);
 		const parsed = parser.parse(contents);
 
 		const importQuery = grammar.query(importOrRequireQuery);


### PR DESCRIPTION
Because we have to load the WASM files as runtime, the CLI was failing to load them because when the CLI is bundled the paths are different.

This moves the WASM files in to the ast directory and then ensures they are copied into the dist.