### PR TITLE
Better handling of grammar and parser

### DIFF
--- a/l10n-dev/package-lock.json
+++ b/l10n-dev/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@vscode/l10n-dev",
-	"version": "0.0.20",
+	"version": "0.0.21",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@vscode/l10n-dev",
-			"version": "0.0.20",
+			"version": "0.0.21",
 			"license": "MIT",
 			"dependencies": {
 				"deepmerge-json": "^1.5.0",

--- a/l10n-dev/package.json
+++ b/l10n-dev/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vscode/l10n-dev",
-	"version": "0.0.20",
+	"version": "0.0.21",
 	"description": "Development time npm module to generate strings bundles from TypeScript files",
 	"author": "Microsoft Corporation",
 	"license": "MIT",

--- a/l10n-dev/src/ast/test/analyzer.test.ts
+++ b/l10n-dev/src/ast/test/analyzer.test.ts
@@ -29,7 +29,7 @@ describe('ScriptAnalyzer', async () => {
                 assert.strictEqual(Object.keys(result!).length, 1);
                 assert.strictEqual(result![basecaseText]!, basecaseText);
             }
-        });
+        }).timeout(10000);
     
         it('require js', async () => {
             const analyzer = new ScriptAnalyzer();

--- a/l10n-dev/src/ast/test/analyzer.test.ts
+++ b/l10n-dev/src/ast/test/analyzer.test.ts
@@ -16,6 +16,20 @@ describe('ScriptAnalyzer', async () => {
             assert.strictEqual(Object.keys(result!).length, 1);
             assert.strictEqual(result![basecaseText]!, basecaseText);
         });
+
+        it('require ensure it can run on multiple files', async () => {
+            const analyzer = new ScriptAnalyzer();
+            for (let i = 0; i < 10; i++) {
+                const result = await analyzer.analyze({
+                    extension: '.ts',
+                    contents: `
+                        const vscode = require('vscode');
+                        vscode.l10n.t('${basecaseText}');`
+                });
+                assert.strictEqual(Object.keys(result!).length, 1);
+                assert.strictEqual(result![basecaseText]!, basecaseText);
+            }
+        });
     
         it('require js', async () => {
             const analyzer = new ScriptAnalyzer();


### PR DESCRIPTION
In the VS Code repo, I was seeing an issue where the parser and grammar were being loaded multiple times

And in some cases, because of my if not checking if the grammar was defined, it would totally fail.

This change ensures that both grammar and parser will be defined.