### PR TITLE
Fix escaped quotes

### DIFF
--- a/l10n-dev/package-lock.json
+++ b/l10n-dev/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@vscode/l10n-dev",
-	"version": "0.0.21",
+	"version": "0.0.22",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@vscode/l10n-dev",
-			"version": "0.0.21",
+			"version": "0.0.22",
 			"license": "MIT",
 			"dependencies": {
 				"deepmerge-json": "^1.5.0",

--- a/l10n-dev/package.json
+++ b/l10n-dev/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vscode/l10n-dev",
-	"version": "0.0.21",
+	"version": "0.0.22",
 	"description": "Development time npm module to generate strings bundles from TypeScript files",
 	"author": "Microsoft Corporation",
 	"license": "MIT",

--- a/l10n-dev/src/ast/test/analyzer.test.ts
+++ b/l10n-dev/src/ast/test/analyzer.test.ts
@@ -16,21 +16,6 @@ describe('ScriptAnalyzer', async () => {
             assert.strictEqual(Object.keys(result!).length, 1);
             assert.strictEqual(result![basecaseText]!, basecaseText);
         });
-
-        it('require ensure it can run on multiple files', async () => {
-            const analyzer = new ScriptAnalyzer();
-            for (let i = 0; i < 10; i++) {
-                const result = await analyzer.analyze({
-                    extension: '.ts',
-                    contents: `
-                        const vscode = require('vscode');
-                        vscode.l10n.t('${basecaseText}');`
-                });
-                assert.strictEqual(Object.keys(result!).length, 1);
-                assert.strictEqual(result![basecaseText]!, basecaseText);
-            }
-        }).timeout(10000);
-    
         it('require js', async () => {
             const analyzer = new ScriptAnalyzer();
             const result = await analyzer.analyze({
@@ -141,6 +126,20 @@ describe('ScriptAnalyzer', async () => {
             assert.strictEqual(Object.keys(result!).length, 1);
             assert.strictEqual(result![basecaseText]!, basecaseText);
         });
+
+        it('require ensure it can run on multiple files', async () => {
+            const analyzer = new ScriptAnalyzer();
+            for (let i = 0; i < 10; i++) {
+                const result = await analyzer.analyze({
+                    extension: '.ts',
+                    contents: `
+                        const vscode = require('vscode');
+                        vscode.l10n.t('${basecaseText}');`
+                });
+                assert.strictEqual(Object.keys(result!).length, 1);
+                assert.strictEqual(result![basecaseText]!, basecaseText);
+            }
+        }).timeout(10000);
     });
 
     context('importing @vscode/l10n', async () => {
@@ -281,6 +280,18 @@ describe('ScriptAnalyzer', async () => {
             assert.strictEqual((result!['foobar/foo\nbarbar\nfoo']! as { message: string }).message, 'foobar');
             assert.strictEqual((result!['foobar/foo\nbarbar\nfoo']! as { comment: string[] }).comment[0], 'foo\nbar');
             assert.strictEqual((result!['foobar/foo\nbarbar\nfoo']! as { comment: string[] }).comment[1], 'bar\nfoo');
+        });
+
+        it('exports escaped quotes correctly', async () => {
+            const analyzer = new ScriptAnalyzer();
+            const result = await analyzer.analyze({
+                extension: '.ts',
+                contents: `
+                    import * as l10n from '@vscode/l10n';
+                    l10n.t('foo\\'bar');`
+            });
+            assert.strictEqual(Object.keys(result!).length, 1);
+            assert.strictEqual(result!['foo\'bar']!, 'foo\'bar');
         });
     });
 });


### PR DESCRIPTION
tree-sitter gives the text as is... so if a message says `'foo\'bar'` you're gonna get `'foo\'bar'` exactly.

This needs to be handled so that the escaped single quote becomes only a single quote in the end.

Fixes #73