### PR TITLE
Handle escape characters better and honor `l10n` in package.json

### DIFF
--- a/l10n-dev/src/ast/analyzer.ts
+++ b/l10n-dev/src/ast/analyzer.ts
@@ -58,14 +58,15 @@ export class ScriptAnalyzer {
 		}
 		if (commentCapture.node.type === 'string') {
 			const text = commentCapture.node.text;
-			// remove quotes
-			return [text.substring(1, text.length - 1)];
+			// remove quotes using indirect eval
+			return [(0, eval)(text)];
 		}
 
 		// we have an array of comments
 		return commentCapture.node.children
 			.filter(c => c.type === 'string')
-			.map(c => c.children[1]!.text);
+			// remove quotes using indirect eval
+			.map(c => (0, eval)(c.text));
 	}
 
 	#getStringFromMatch(match: QueryMatch, id: string, removeQuotes: boolean): string | undefined {
@@ -83,7 +84,8 @@ export class ScriptAnalyzer {
 		if (character !== '\'' && character !== '"' && character !== '`') {
 			return text;
 		}
-		return text.substring(1, text.length - 1).replace(new RegExp(`\\\\${character}`, 'g'), () => character);
+		// remove quotes using indirect eval
+		return (0, eval)(text);
 	}
 
 	#getImportDetails(match: QueryMatch): IAlternativeVariableNames {

--- a/l10n-dev/src/ast/test/analyzer.test.ts
+++ b/l10n-dev/src/ast/test/analyzer.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-escape */
 import * as assert from 'assert';
 import { ScriptAnalyzer } from '../analyzer';
 
@@ -259,7 +260,7 @@ describe('ScriptAnalyzer', async () => {
                 extension: '.ts',
                 contents: `
                 import { l10n } from 'vscode';
-                l10n.t('foo\nbar');`
+                l10n.t('foo\\nbar');`
             });
             assert.strictEqual(Object.keys(result!).length, 1);
             assert.strictEqual(result!['foo\nbar']!, 'foo\nbar');
@@ -273,7 +274,7 @@ describe('ScriptAnalyzer', async () => {
                 import { l10n } from 'vscode';
                 l10n.t({
                     message: 'foobar',
-                    comment: ['foo\nbar', 'bar\nfoo']
+                    comment: ['foo\\nbar', 'bar\\nfoo']
                 });`
             });
             assert.strictEqual(Object.keys(result!).length, 1);
@@ -292,6 +293,18 @@ describe('ScriptAnalyzer', async () => {
             });
             assert.strictEqual(Object.keys(result!).length, 1);
             assert.strictEqual(result!['foo\'bar']!, 'foo\'bar');
+        });
+
+        it('exports unnecessary escaped characters correctly', async () => {
+            const analyzer = new ScriptAnalyzer();
+            const result = await analyzer.analyze({
+                extension: '.ts',
+                contents: `
+                    import * as l10n from '@vscode/l10n';
+                    l10n.t('foo\"bar');`
+            });
+            assert.strictEqual(Object.keys(result!).length, 1);
+            assert.strictEqual(result!['foo\"bar']!, 'foo\"bar');
         });
     });
 });

--- a/l10n-dev/src/test/cli.test.ts
+++ b/l10n-dev/src/test/cli.test.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { readFileSync } from "fs";
+import mock from "mock-fs";
+import path from "path";
+import * as cli from "../cli";
+
+describe('cli', () => {
+	context('l10nExportStrings', () => {
+		before(() => {
+			mock({
+				'big.ts': mock.load(path.resolve(__dirname, 'testcases/big.txt')),
+				'package.json': '{ "l10n": "./l10n"}'
+			});
+		})
+		afterEach(() => {
+			mock.restore();
+		});
+		it('big.ts', async () => {
+			await cli.l10nExportStrings(['big.ts'], 'l10n');
+			const result = readFileSync('l10n/bundle.l10n.json', 'utf8');
+			const actualLines = result.split('\n');
+			const expectedLines = [
+				'{',
+				// simple case
+				'  "Hello World": "Hello World",',
+				// simple case with quote
+				'  "foo\'bar": "foo\'bar",',
+				// simple case with escaped quote
+				'  "foo\\"bar": "foo\\"bar",',
+				// simple case with newline
+				'  "foo\\nbaz": "foo\\nbaz",',
+				// comment case
+				'  "foobar/foobar": {',
+				'    "message": "foobar",',
+				'    "comment": [',
+				'      "foobar"',
+				'    ]',
+				'  },',
+				// comment case with newline
+				'  "foobar/foo\\nbarbar\\nfoo": {',
+				'    "message": "foobar",',
+				'    "comment": [',
+				'      "foo\\nbar",',
+				'      "bar\\nfoo"',
+				'    ]',
+				'  }',
+				'}',
+			]
+
+			for (let i = 0; i < expectedLines.length; i++) {
+				const expectedLine = expectedLines[i];
+				const actualLine = actualLines[i];
+				assert.strictEqual(actualLine, expectedLine);
+			}
+		});
+	});
+});

--- a/l10n-dev/src/test/testcases/big.txt
+++ b/l10n-dev/src/test/testcases/big.txt
@@ -1,0 +1,14 @@
+import { l10n } from "vscode";
+
+l10n.t("Hello World");
+l10n.t('foo\'bar');
+l10n.t('foo\"bar');
+l10n.t('foo\nbaz');
+l10n.t({
+    message: 'foobar',
+    comment: ['foobar']
+});
+l10n.t({
+    message: 'foobar',
+    comment: ['foo\nbar', 'bar\nfoo']
+});


### PR DESCRIPTION
Use an indirect eval to ensure escape characters are handled correctly.

Since the client will be "running" the string inside of `l10n.t()` this is the best way to ensure alignment.

Note that our query currently doesn't pick up references like this:
* `l10n.t("foo" + "bar")`
* or:
```
l10n.t(`backticks`)
```

So we don't have to worry about eval failing.

Fixes #73 
Fixes #76 
Fixes #66 