### PR TITLE
fix: mark @vscode/l10n as side-effect-free

### DIFF
--- a/l10n/package.json
+++ b/l10n/package.json
@@ -12,6 +12,7 @@
 		"url": "https://github.com/Microsoft/vscode-l10n/issues"
 	},
 	"main": "./dist/main.js",
+	"sideEffects": false,
 	"browser": {
 		"./dist/main.js": "./dist/browser.js",
 		"./src/node/reader": "./src/browser/reader"

--- a/l10n/package.json
+++ b/l10n/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vscode/l10n",
-	"version": "0.0.12",
+	"version": "0.0.13",
 	"description": "A helper library to assist in localizing subprocesses spun up by VS Code extensions",
 	"author": "Microsoft Corporation",
 	"license": "MIT",


### PR DESCRIPTION
Refs https://github.com/microsoft/vscode-js-debug/issues/1624

I noticed that issue was being called by new syntax being used in the bootloader that Node 12 didn't understand. But localizations shouldn't be in the bootloader at all, and with this change, it enables @vscode/l10n to be tree shaken out.

Separate issue is why our test suites that nominally run Node 8 didn't pick up on this earlier...