### PR TITLE
feat: add `l10n.lit` for tagged template literal translations (it's lit)

### DIFF
--- a/l10n-dev/src/ast/queries.ts
+++ b/l10n-dev/src/ast/queries.ts
@@ -7,6 +7,7 @@ export interface IAlternativeVariableNames {
 	vscode?: string;
 	l10n?: string;
 	t?: string;
+	lit?: string;
 }
 
 // matches require('vscode') and require('@vscode/l10n')
@@ -61,15 +62,31 @@ export const importOrRequireQuery = `${variableDeclaratorRequireQuery}
 ${assignmentExpressionRequireQuery}
 ${importQuery}`;
 
-// Gets a query that will find and extract all t() calls into @message and @comment
-export function getTQuery({ vscode, l10n, t}: IAlternativeVariableNames): string {
-	return `(call_expression 
+export function getLitQuery({ vscode = 'vscode', l10n = 'l10n', lit = 'lit' }: IAlternativeVariableNames): string {
+	return `(call_expression
 	(member_expression
 		object: [
-			((identifier) @l10n (#eq? @l10n ${l10n ?? 'l10n'}))
-			(member_expression 
-				object: (identifier) @vscode (#eq? @vscode ${vscode ?? 'vscode'})
-				property: (property_identifier) @l10n (#eq? @l10n ${l10n ?? 'l10n'})
+			((identifier) @l10n (#eq? @l10n ${l10n}))
+			(member_expression
+				object: (identifier) @vscode (#eq? @vscode ${vscode})
+				property: (property_identifier) @l10n (#eq? @l10n ${l10n})
+			)
+		]
+		property: (property_identifier) @t (#eq? @t ${lit ?? 'lit'})
+	)
+	arguments: (template_string (template_substitution)* @sub) @str
+)`;
+}
+
+// Gets a query that will find and extract all t() calls into @message and @comment
+export function getTQuery({ vscode = 'vscode', l10n = 'l10n', t = 't' }: IAlternativeVariableNames): string {
+	return `(call_expression
+	(member_expression
+		object: [
+			((identifier) @l10n (#eq? @l10n ${l10n}))
+			(member_expression
+				object: (identifier) @vscode (#eq? @vscode ${vscode})
+				property: (property_identifier) @l10n (#eq? @l10n ${l10n})
 			)
 		]
 		property: (property_identifier) @t (#eq? @t ${t ?? 't'})
@@ -78,11 +95,11 @@ export function getTQuery({ vscode, l10n, t}: IAlternativeVariableNames): string
 		(arguments . (string) @message)
 		(arguments . (number) @message)
 		(arguments . (object
-			(pair 
+			(pair
 				key: (property_identifier) @message-prop (#eq? @message-prop message)
 				value: (string) @message
 			)
-			(pair 
+			(pair
 				key: (property_identifier) @comment-prop (#eq? @comment-prop comment)
 				value: [
 					((string) @comment)

--- a/l10n-dev/src/ast/queries.ts
+++ b/l10n-dev/src/ast/queries.ts
@@ -7,7 +7,6 @@ export interface IAlternativeVariableNames {
 	vscode?: string;
 	l10n?: string;
 	t?: string;
-	lit?: string;
 }
 
 // matches require('vscode') and require('@vscode/l10n')
@@ -62,22 +61,6 @@ export const importOrRequireQuery = `${variableDeclaratorRequireQuery}
 ${assignmentExpressionRequireQuery}
 ${importQuery}`;
 
-export function getLitQuery({ vscode = 'vscode', l10n = 'l10n', lit = 'lit' }: IAlternativeVariableNames): string {
-	return `(call_expression
-	(member_expression
-		object: [
-			((identifier) @l10n (#eq? @l10n ${l10n}))
-			(member_expression
-				object: (identifier) @vscode (#eq? @vscode ${vscode})
-				property: (property_identifier) @l10n (#eq? @l10n ${l10n})
-			)
-		]
-		property: (property_identifier) @t (#eq? @t ${lit ?? 'lit'})
-	)
-	arguments: (template_string (template_substitution)* @sub) @str
-)`;
-}
-
 // Gets a query that will find and extract all t() calls into @message and @comment
 export function getTQuery({ vscode = 'vscode', l10n = 'l10n', t = 't' }: IAlternativeVariableNames): string {
 	return `(call_expression
@@ -92,6 +75,7 @@ export function getTQuery({ vscode = 'vscode', l10n = 'l10n', t = 't' }: IAltern
 		property: (property_identifier) @t (#eq? @t ${t ?? 't'})
 	)
 	arguments: [
+		(template_string (template_substitution)* @sub) @template
 		(arguments . (string) @message)
 		(arguments . (number) @message)
 		(arguments . (object

--- a/l10n-dev/src/ast/test/analyzer.test.ts
+++ b/l10n-dev/src/ast/test/analyzer.test.ts
@@ -191,7 +191,7 @@ describe('ScriptAnalyzer', async () => {
         });
     });
 
-    context('usage of l10n.lit', async () => {
+    context('usage of l10n.t literal', async () => {
         it('args are object with comment as string', async () => {
             const analyzer = new ScriptAnalyzer();
             const key = `hello {0} and {1}!`;
@@ -199,18 +199,18 @@ describe('ScriptAnalyzer', async () => {
                 extension: '.ts',
                 contents: `
                     import { l10n } from 'vscode';
-                    l10n.lit\`hello \${name} and \${other}!\`;`
+                    l10n.t\`hello \${name} and \${other}!\`;`
             });
             assert.deepStrictEqual(result, { [key]: 'hello {0} and {1}!' });
         });
 
-        it('does not count other lit functions', async () => {
+        it('does not count other t functions', async () => {
             const analyzer = new ScriptAnalyzer();
             const result = await analyzer.analyze({
                 extension: '.ts',
                 contents: `
                     import * as i18next from 'i18next';
-                    i18next.lit\`${basecaseText}\`;`
+                    i18next.t\`${basecaseText}\`;`
             });
             assert.deepStrictEqual(result, {});
         });
@@ -221,7 +221,7 @@ describe('ScriptAnalyzer', async () => {
                 extension: '.ts',
                 contents: `
                     import * as l10n from '@vscode/l10n';
-                    l10n.lit\`foo\\\`bar\``
+                    l10n.t\`foo\\\`bar\``
             });
             assert.deepStrictEqual(result, { 'foo`bar': 'foo`bar' });
         });
@@ -232,7 +232,7 @@ describe('ScriptAnalyzer', async () => {
                 extension: '.ts',
                 contents: `
                     import * as l10n from '@vscode/l10n';
-                    l10n.lit\`foo\\"bar'\``
+                    l10n.t\`foo\\"bar'\``
             });
             assert.deepStrictEqual(result, { 'foo"bar\'': 'foo"bar\'' });
         });

--- a/l10n-dev/src/ast/test/unescapeString.test.ts
+++ b/l10n-dev/src/ast/test/unescapeString.test.ts
@@ -1,0 +1,20 @@
+import * as assert from 'assert';
+import { unescapeString } from '../unescapeString';
+
+describe('unescapeString', async () => {
+  const testTable = [
+    ['a\\nb', 'a\nb'],
+    ['a\\rb', 'a\rb'],
+    ['\\x20', ' '],
+    ['\\u{20}', ' '],
+    ['\\u{1F600}', '😀'],
+    ['h\'el`l"\\o', 'h\'el`l"o'],
+    ['\\\\\\\'\\`\\"', '\\\'`"'],
+  ] as const;
+
+  for (const [input, expected] of testTable) {
+    it(`should unescape ${input} to ${expected}`, () => {
+      assert.strictEqual(unescapeString(input), expected);
+    });
+  }
+});

--- a/l10n-dev/src/ast/unescapeString.ts
+++ b/l10n-dev/src/ast/unescapeString.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Replaces escaped sequences in the string, including:
+ *
+ *  - Standard escapes (\r, \n, \t, and standard chars)
+ *  - Unicode escapes (\xFF, \uFFFF, \u{10FFFF})
+ *
+ * Its behavior is undefined if the `text` is not a valid ECMAScript string.
+ *
+ * @see https://exploringjs.com/es6/ch_unicode.html
+ */
+export const unescapeString = (text: string): string => {
+  for (let i = text.indexOf('\\'); i !== -1; i = text.indexOf('\\', i)) {
+    if (text[i] !== '\\') {
+      i++;
+      continue;
+    }
+
+    let replace: string;
+    let end = i + 2;
+    const next = text[i + 1];
+
+    switch (next) {
+      case 'n':
+        replace = '\n';
+        break;
+      case 'r':
+        replace = '\r';
+        break;
+      case 't':
+        replace = '\t';
+        break;
+      case 'x':
+        end = i + 4;
+        replace = String.fromCodePoint(parseInt(text.slice(i + 2, end), 16)); // hex escape, \xXX
+        break;
+      case 'u': {
+        let int: string;
+        if (text[i + 2] === '{') {
+          end = text.indexOf('}') + 1; // unicode code point, \u{XX..}
+          int = text.slice(i + 3, end - 1);
+        } else {
+          end = i + 6; // unicode code point, \uXXXX
+          int = text.slice(i + 2, end - 1);
+        }
+        replace = String.fromCodePoint(parseInt(int, 16));
+        break;
+      }
+      default:
+        replace = next!;
+        break;
+    }
+
+    text = text.slice(0, i) + replace + text.slice(end);
+    i += replace.length;
+  }
+
+  return text;
+};

--- a/l10n/src/test/main.test.ts
+++ b/l10n/src/test/main.test.ts
@@ -221,7 +221,7 @@ describe('@vscode/l10n', () => {
 
         const a = 'foo';
         const b = 'bar';
-        assert.strictEqual(l10n.lit`original ${a} message ${b}`, "translated foo message bar");
+        assert.strictEqual(l10n.t`original ${a} message ${b}`, "translated foo message bar");
     });
 
     //#region error cases

--- a/l10n/src/test/main.test.ts
+++ b/l10n/src/test/main.test.ts
@@ -54,8 +54,7 @@ describe('@vscode/l10n', () => {
 
     it('load from file uri', async () => {
         mock({
-            '/mock-bundle.json': `{ "message": "translated message" }`,
-            'C:\\mock-bundle.json': `{ "message": "translated message" }`
+            [process.platform === 'win32' ? 'C:\\mock-bundle.json' : '/mock-bundle.json']: `{ "message": "translated message" }`,
         });
         await l10n.config({ uri: new URL(platform === 'win32' ? 'file:///c:/mock-bundle.json' : 'file:///mock-bundle.json') });
 
@@ -68,8 +67,7 @@ describe('@vscode/l10n', () => {
 
     it('load from file uri as string', async () => {
         mock({
-            '/mock-bundle.json': `{ "message": "translated message" }`,
-            'C:\\mock-bundle.json': `{ "message": "translated message" }`
+            [process.platform === 'win32' ? 'C:\\mock-bundle.json' : '/mock-bundle.json']: `{ "message": "translated message" }`,
         });
         await l10n.config({
             uri: new URL(platform === 'win32' ? 'file:///c:/mock-bundle.json' : 'file:///mock-bundle.json').toString()
@@ -103,8 +101,7 @@ describe('@vscode/l10n', () => {
 
     it('load from fsPath', async () => {
         mock({
-            '/mock-bundle.json': `{ "message": "translated message" }`,
-            'C:\\mock-bundle.json': `{ "message": "translated message" }`
+            [process.platform === 'win32' ? 'C:\\mock-bundle.json' : '/mock-bundle.json']: `{ "message": "translated message" }`,
         });
         l10n.config({
             fsPath: platform === 'win32' ? 'C:\\mock-bundle.json' : '/mock-bundle.json'
@@ -118,8 +115,7 @@ describe('@vscode/l10n', () => {
 
     it('load from fsPath with built-in schema', async () => {
         mock({
-            '/mock-bundle.json': '{ "version": "1.0.0", "contents": { "bundle": { "message": "translated message" } } }',
-            'C:\\mock-bundle.json': '{ "version": "1.0.0", "contents": { "bundle": { "message": "translated message" } } }'
+            [process.platform === 'win32' ? 'C:\\mock-bundle.json' : '/mock-bundle.json']: '{ "version": "1.0.0", "contents": { "bundle": { "message": "translated message" } } }',
         });
         l10n.config({
             fsPath: platform === 'win32' ? 'C:\\mock-bundle.json' : '/mock-bundle.json'
@@ -164,7 +160,7 @@ describe('@vscode/l10n', () => {
             }
         });
 
-        // Normally we would be more static in the declaration of the object 
+        // Normally we would be more static in the declaration of the object
         // in order to extract them properly but for tests we don't need to do that.
         assert.strictEqual(l10n.t({
             message,
@@ -185,7 +181,7 @@ describe('@vscode/l10n', () => {
             }
         });
 
-        // Normally we would be more static in the declaration of the object 
+        // Normally we would be more static in the declaration of the object
         // in order to extract them properly but for tests we don't need to do that.
         assert.strictEqual(l10n.t({
             message,
@@ -207,13 +203,25 @@ describe('@vscode/l10n', () => {
             }
         });
 
-        // Normally we would be more static in the declaration of the object 
+        // Normally we would be more static in the declaration of the object
         // in order to extract them properly but for tests we don't need to do that.
         assert.strictEqual(l10n.t({
             message,
             comment: [comment],
             args: { this: 'foo' }
         }), result);
+    });
+
+    it('supports template literals', () => {
+        l10n.config({
+            contents: {
+                'original {0} message {1}': 'translated {0} message {1}'
+            }
+        });
+
+        const a = 'foo';
+        const b = 'bar';
+        assert.strictEqual(l10n.lit`original ${a} message ${b}`, "translated foo message bar");
     });
 
     //#region error cases


### PR DESCRIPTION
This adds a new format of localization that can be used like

```js
l10n.lit`Hello ${name}!`
```

This approach makes it easier to write translations without an
error-prone process of manual replacements (https://github.com/microsoft/vscode-js-debug/pull/1693/files)
Template literals do not allow for comments; for that I suggest users
go back to `l10n.t`. I thought about some overload syntax that would be
a higher order function like

```js
l10n.lit({ comment: 'here' })`Hello ${name}!`
```

...which could be a nice future addition?

This is not supported in the vscode ext host API yet... but it could be :)