### PR TITLE
Use glob library more

### DIFF
--- a/l10n-dev/package-lock.json
+++ b/l10n-dev/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@vscode/l10n-dev",
-	"version": "0.0.25",
+	"version": "0.0.26",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@vscode/l10n-dev",
-			"version": "0.0.25",
+			"version": "0.0.26",
 			"license": "MIT",
 			"dependencies": {
 				"deepmerge-json": "^1.5.0",

--- a/l10n-dev/package.json
+++ b/l10n-dev/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vscode/l10n-dev",
-	"version": "0.0.25",
+	"version": "0.0.26",
 	"description": "Development time npm module to generate strings bundles from TypeScript files",
 	"author": "Microsoft Corporation",
 	"license": "MIT",

--- a/l10n-dev/src/test/cli.test.ts
+++ b/l10n-dev/src/test/cli.test.ts
@@ -142,4 +142,34 @@ describe('cli', () => {
 			}
 		});
 	});
+
+	context('l10nGeneratePseudo', () => {
+		before(() => {
+			mock({
+				'bundle.l10n.json': mock.load(path.resolve(__dirname, 'testcases/testBundle.json'))
+			});
+		})
+		afterEach(() => {
+			mock.restore();
+		});
+		it('big file of test cases', async () => {
+			cli.l10nGeneratePseudo(['bundle.l10n.json'], 'qps-ploc');
+			const result = readFileSync('bundle.l10n.qps-ploc.json', 'utf8');
+			const actualLines = result.split(/\r?\n/);
+			const expectedLines = [
+				'{',
+				'  "Hello World": "Ħḗḗŀŀǿǿ Ẇǿǿřŀḓ",',
+				'  "foo\'bar": "ƒǿǿǿǿ\'ƀȧȧř",',
+				'  "foo\\"bar": "ƒǿǿǿǿ\\"ƀȧȧř",',
+				'  "foo\\nbaz": "ƒǿǿǿǿ\\nƀȧȧẑ",',
+				'  "foobar/foobarbarfoo": "ƒǿǿǿǿƀȧȧř"',
+				'}',
+			];
+			for (let i = 0; i < expectedLines.length; i++) {
+				const expectedLine = expectedLines[i];
+				const actualLine = actualLines[i];
+				assert.strictEqual(actualLine, expectedLine);
+			}
+		});
+	});
 });


### PR DESCRIPTION
The glob library is very powerful. This change refactors things so that there are no more nested globs. Additionally, I got rid of the nasty `toPosixPath` function.

Oh, and added a cli test for pseudo generation.