### PR TITLE
Passing outDir to command always outputs warning that it doesn't match packageJSON.l10n value.

### DIFF
--- a/l10n-dev/package-lock.json
+++ b/l10n-dev/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@vscode/l10n-dev",
-	"version": "0.0.26",
+	"version": "0.0.27",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@vscode/l10n-dev",
-			"version": "0.0.26",
+			"version": "0.0.27",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.3.4",

--- a/l10n-dev/package.json
+++ b/l10n-dev/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vscode/l10n-dev",
-	"version": "0.0.26",
+	"version": "0.0.27",
 	"description": "Development time npm module to generate strings bundles from TypeScript files",
 	"author": "Microsoft Corporation",
 	"license": "MIT",

--- a/l10n-dev/src/cli.ts
+++ b/l10n-dev/src/cli.ts
@@ -162,7 +162,7 @@ export async function l10nExportStrings(paths: string[], outDir?: string): Promi
 	}
 	if (packageJSON) {
 		if (outDir) {
-			if (!packageJSON.l10n || path.resolve(packageJSON.l10n) === path.resolve(outDir)) {
+			if (!packageJSON.l10n || path.resolve(packageJSON.l10n) !== path.resolve(outDir)) {
 				console.warn('The l10n property in the package.json does not match the outDir specified. For an extension to work correctly, l10n must be set to the location of the bundle files.');
 			}
 		} else {


### PR DESCRIPTION
Fixes #115