### PR TITLE
fix: allow template strings in `l10n.t` calls

### DIFF
--- a/l10n-dev/src/ast/analyzer.ts
+++ b/l10n-dev/src/ast/analyzer.ts
@@ -185,6 +185,10 @@ export class ScriptAnalyzer {
 					message = this.#getUnquotedString(message);
 				} else {
 					message = this.#getStringFromMatch(match, 'message', true)!;
+					const hasMessageTemplateArgs = match.captures.find(c => c.name === 'message_template_arg');
+					if (hasMessageTemplateArgs) {
+						throw new Error(`Message '${message}' contains template args. Please use double quotes and pass args.`);
+					}
 				}
 
 				const comment = this.#getCommentsFromMatch(match);

--- a/l10n-dev/src/ast/queries.ts
+++ b/l10n-dev/src/ast/queries.ts
@@ -81,7 +81,7 @@ export function getTQuery({ vscode = 'vscode', l10n = 'l10n', t = 't' }: IAltern
 			(arguments . (object
 				(pair
 					key: (property_identifier) @message-prop (#eq? @message-prop message)
-					value: [(string) (template_string)] @message
+					value: [(string) (template_string (template_substitution)? @message_template_arg)] @message
 				)
 				(pair
 					key: (property_identifier) @comment-prop (#eq? @comment-prop comment)

--- a/l10n-dev/src/ast/queries.ts
+++ b/l10n-dev/src/ast/queries.ts
@@ -64,33 +64,30 @@ ${importQuery}`;
 // Gets a query that will find and extract all t() calls into @message and @comment
 export function getTQuery({ vscode = 'vscode', l10n = 'l10n', t = 't' }: IAlternativeVariableNames): string {
 	return `(call_expression
-	(member_expression
-		object: [
-			((identifier) @l10n (#eq? @l10n ${l10n}))
-			(member_expression
-				object: (identifier) @vscode (#eq? @vscode ${vscode})
-				property: (property_identifier) @l10n (#eq? @l10n ${l10n})
-			)
+		(member_expression
+			object: [
+				((identifier) @l10n (#eq? @l10n ${l10n}))
+				(member_expression
+					object: (identifier) @vscode (#eq? @vscode ${vscode})
+					property: (property_identifier) @l10n (#eq? @l10n ${l10n})
+				)
+			]
+			property: (property_identifier) @t (#eq? @t ${t})
+		)
+		arguments: [
+			(template_string (template_substitution)* @sub) @template
+			(arguments . [(string) (template_string)] @message)
+			(arguments . (number) @message)
+			(arguments . (object
+				(pair
+					key: (property_identifier) @message-prop (#eq? @message-prop message)
+					value: [(string) (template_string)] @message
+				)
+				(pair
+					key: (property_identifier) @comment-prop (#eq? @comment-prop comment)
+					value: [(string) (array) (template_string)] @comment
+				)
+			))
 		]
-		property: (property_identifier) @t (#eq? @t ${t ?? 't'})
-	)
-	arguments: [
-		(template_string (template_substitution)* @sub) @template
-		(arguments . (string) @message)
-		(arguments . (number) @message)
-		(arguments . (object
-			(pair
-				key: (property_identifier) @message-prop (#eq? @message-prop message)
-				value: (string) @message
-			)
-			(pair
-				key: (property_identifier) @comment-prop (#eq? @comment-prop comment)
-				value: [
-					((string) @comment)
-					((array) @comment)
-				]
-			)
-		))
-	]
-)`;
+	)`;
 }

--- a/l10n-dev/src/ast/test/analyzer.test.ts
+++ b/l10n-dev/src/ast/test/analyzer.test.ts
@@ -357,13 +357,14 @@ describe('ScriptAnalyzer', async () => {
         it('allows template literal messages without template args in l10n.t() calls', async () => {
             const analyzer = new ScriptAnalyzer();
             const result = await analyzer.analyze({ extension: '.ts', contents: 'import * as l10n from @vscode/l10n\nl10n.t(`foo`)' });
-            assert.deepStrictEqual(result, { foo: 'foo' });
+            assert.strictEqual(Object.keys(result!).length, 1);
+            assert.strictEqual(result!['foo']!, 'foo');
         });
 
         it('disallows template literal messages containing template args in l10n.t() calls', async () => {
             const analyzer = new ScriptAnalyzer();
             const result = analyzer.analyze({ extension: '.ts', contents: 'import * as l10n from @vscode/l10n\nl10n.t(`${42}`)' });
-            assert.throws(() => result);
+            assert.rejects(() => result);
         });
     });
 });

--- a/l10n-dev/src/ast/test/analyzer.test.ts
+++ b/l10n-dev/src/ast/test/analyzer.test.ts
@@ -356,7 +356,7 @@ describe('ScriptAnalyzer', async () => {
 
         it('allows template literal messages without template args in l10n.t() calls', async () => {
             const analyzer = new ScriptAnalyzer();
-            const result = await analyzer.analyze({ extension: '.ts', contents: 'import * as l10n from @vscode/l10n\nl10n.t(`foo`)' });
+            const result = await analyzer.analyze({ extension: '.ts', contents: "import * as l10n from '@vscode/l10n';\nl10n.t(`foo`)" });
             assert.strictEqual(Object.keys(result!).length, 1);
             assert.strictEqual(result!['foo']!, 'foo');
         });

--- a/l10n-dev/src/ast/test/analyzer.test.ts
+++ b/l10n-dev/src/ast/test/analyzer.test.ts
@@ -353,5 +353,17 @@ describe('ScriptAnalyzer', async () => {
             assert.strictEqual(Object.keys(result!).length, 1);
             assert.strictEqual(result!['foo\"bar']!, 'foo\"bar');
         });
+
+        it('allows template literal messages without template args in l10n.t() calls', async () => {
+            const analyzer = new ScriptAnalyzer();
+            const result = await analyzer.analyze({ extension: '.ts', contents: 'import * as l10n from @vscode/l10n\nl10n.t(`foo`)' });
+            assert.deepStrictEqual(result, { foo: 'foo' });
+        });
+
+        it('disallows template literal messages containing template args in l10n.t() calls', async () => {
+            const analyzer = new ScriptAnalyzer();
+            const result = analyzer.analyze({ extension: '.ts', contents: 'import * as l10n from @vscode/l10n\nl10n.t(`${42}`)' });
+            assert.throws(() => result);
+        });
     });
 });


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-l10n/issues/78