### PR TITLE
chore: skip APIScan for l10n-dev

### DIFF
--- a/build/pipeline.yml
+++ b/build/pipeline.yml
@@ -65,6 +65,7 @@ extends:
         publishPackage: ${{ parameters.publishPackage1 }}
         workingDirectory: $(Build.SourcesDirectory)/l10n-dev
         publishRequiresApproval: false
+        skipAPIScan: true # Requires Linux to build WASM grammars
 
       - name: l10n
 


### PR DESCRIPTION
Verification build https://dev.azure.com/monacotools/Monaco/_build/results?buildId=259791&view=results