### PR TITLE
Workaround tree-sitter bug

### DIFF
--- a/l10n-dev/src/ast/analyzer.ts
+++ b/l10n-dev/src/ast/analyzer.ts
@@ -189,7 +189,10 @@ export class ScriptAnalyzer {
 				let message: string;
 				// handles l10n.t`foo`
 				if (taggedTemplate) {
-					const subs = match.captures.filter(c => c.name === 'sub');
+					const subs = match.captures
+						.filter(c => c.name === 'sub')
+						// Workaround for https://github.com/tree-sitter/tree-sitter-typescript/issues/339
+						.filter(c => c.node.type === 'template_substitution');
 					const start = taggedTemplate.node.startIndex;
 					message = this.#getTemplateValueFromTemplateRawValue(taggedTemplate.node.text);
 					for (let i = subs.length - 1; i >= 0; i--) {

--- a/l10n-dev/src/ast/queries.ts
+++ b/l10n-dev/src/ast/queries.ts
@@ -62,6 +62,8 @@ ${assignmentExpressionRequireQuery}
 ${importQuery}`;
 
 // Gets a query that will find and extract all t() calls into @message and @comment
+// NOTE: the `(_)*` in the template string query is a workaround for
+// https://github.com/tree-sitter/tree-sitter-typescript/issues/339
 export function getTQuery({ vscode = 'vscode', l10n = 'l10n', t = 't' }: IAlternativeVariableNames): string {
 	return `(call_expression
 		(member_expression
@@ -75,7 +77,7 @@ export function getTQuery({ vscode = 'vscode', l10n = 'l10n', t = 't' }: IAltern
 			property: (property_identifier) @t (#eq? @t ${t})
 		)
 		arguments: [
-			(template_string (template_substitution)* @sub) @tagged_template
+			(template_string (_)* @sub) @tagged_template
 			(arguments . [(string) (template_string (template_substitution)? @message_template_arg)] @message)
 			(arguments . (number) @message)
 			(arguments . (object

--- a/l10n-dev/src/ast/test/analyzer.test.ts
+++ b/l10n-dev/src/ast/test/analyzer.test.ts
@@ -193,9 +193,7 @@ describe('ScriptAnalyzer', () => {
     });
 
     describe('usage of l10n.t tagged template', () => {
-        // Skipping for now until https://github.com/tree-sitter/tree-sitter-typescript/issues/339 is
-        // resolved.
-        it.skip('args are object with comment as string', async () => {
+        it('args are object with comment as string', async () => {
             const analyzer = new ScriptAnalyzer();
             const key = `hello {0} and {1}!`;
             const result = await analyzer.analyze({


### PR DESCRIPTION
See this: https://github.com/tree-sitter/tree-sitter-typescript/issues/339

For some reason, being specific`template_substitution` doesn't capture all `template_substitution`s.... so instead we capture all and sort later.