### PR TITLE
chore: bump build time

### DIFF
--- a/build/pipeline.yml
+++ b/build/pipeline.yml
@@ -30,6 +30,7 @@ extends:
   parameters:
     npmPackages:
       - name: l10n-dev
+        timeoutInMinutes: 90
 
         buildSteps:
           - script: |


### PR DESCRIPTION
The pipeline has recently been timing out a bunch. This PR increases the timeout to check whether the build time just is longer these days.